### PR TITLE
Remove hardcoded paths to phantomjs and webdriver-manager

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,16 @@
 var path = require('path');
 
-var phantomjsBinary = path.resolve(__dirname, '../node_modules/.bin/phantomjs');
-var chromeDriver = path.resolve(__dirname, '../node_modules/webdriver-manager/selenium/chromedriver');
+function stripJsExtension(pathToFile) {
+	if (path.extname(pathToFile) === '.js') {
+		pathToFile = pathToFile.slice(0, -3);
+	}
+	return pathToFile;
+}
+
+var webdriverPath = require.resolve('webdriver-manager').replace('/lib/index.js', '');
+var phantomjsBinary = stripJsExtension(require.resolve('phantomjs'));
+var chromeDriver = webdriverPath + '/selenium/chromedriver';
+var seleniumJar = webdriverPath + '/selenium/selenium-server-standalone-2.44.0.jar';
 
 var package = require('../package.json');
 
@@ -9,8 +18,8 @@ exports.description = package.description;
 exports.version = package.version;
 
 exports.paths = {
-	protractorLauncher: require(path.resolve(__dirname, '../node_modules/protractor/lib/launcher')),
-	selenium: path.resolve(__dirname, '../node_modules/webdriver-manager/selenium/selenium-server-standalone-2.44.0.jar')
+	protractorLauncher: require('protractor/lib/launcher'),
+	selenium: seleniumJar
 };
 
 exports.properties = {

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var webDriverManager = require('webdriver-manager');
+var WebDriverManager = require('webdriver-manager');
 var drakov = require('drakov');
 
 var config = require('./config');
@@ -35,7 +35,7 @@ var runDrakov = function(cb) {
 };
 
 var updateAndRunWebdriver = function(cb) {
-	var wd = new webDriverManager();
+	var wd = new WebDriverManager();
 	var drivers = isChromeOnly ? ['chrome'] : ['standalone'];
 	if (drakovArgs) {
 		wd.install(drivers, runDrakov(cb));


### PR DESCRIPTION
npm version 3+ prefers installing dependencies in a flat structure so dependant modules like `phantomjs` and `webdriver-manager` will not always be installed into `grunt-blueprint-test-runner/node_modules`.