### PR TITLE
Include Node.js 5 and update phantomjs to new package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+sudo: required
 language: node_js
+dist: trusty
 node_js:
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.2.6"
+  - "4"
+  - "5"
 notifications:
   email:
     - svarghese@aconex.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blueprint-test-runner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Angular functional test runner using Drakov and Protractor",
   "keywords": [
     "angular",
@@ -25,7 +25,7 @@
   "main": "src/runner.js",
   "dependencies": {
     "drakov": "^0.2.1",
-    "phantomjs": "^2.1.3",
+    "phantomjs-prebuilt": "^2.1.3",
     "protractor": "^3.1.1",
     "webdriver-manager": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,16 +24,17 @@
   },
   "main": "src/runner.js",
   "dependencies": {
-    "drakov": "^0.2.1",
-    "phantomjs-prebuilt": "^2.1.3",
+    "drakov": "^0.2.2",
+    "phantomjs-prebuilt": "^2.1.5",
     "protractor": "^3.1.1",
-    "webdriver-manager": "^2.0.0"
+    "webdriver-manager": "^8.0.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-jshint": "^1.11.2",
+    "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.1.3",
     "gulp-util": "^3.0.6",
+    "jshint": "^2.9.1",
     "jshint-stylish": "^2.0.1"
   }
 }


### PR DESCRIPTION
`phantomjs` package is marked as deprecated, updated to new `phantomjs-prebuilt` package.

Tested in my local Node.js 5, so I've updated the Travis CI config to include it.

I've also taken the liberty of bumping the package version :+1: 

When this is merged don't forget to `npm publish` :+1: 